### PR TITLE
Safely add GET params to admin URLs

### DIFF
--- a/lib/loco-admin.php
+++ b/lib/loco-admin.php
@@ -773,7 +773,7 @@ abstract class LocoAdmin {
                 $args['page'].= '-'.$suffix;
             }
         }
-        return $base_uri.'?'.http_build_query( $args );
+        return add_query_arg($args,$base_uri);
     }
     
     


### PR DESCRIPTION
Use WP add_query_arg() in favor of string concatenation.

Had an issue together with a plugin development. 
... hope you're accepting PRs.
cheers, j.
